### PR TITLE
Support for Android N-ify

### DIFF
--- a/app/src/main/java/net/madnation/zeus/contextual/xposed/SystemUI_hook.java
+++ b/app/src/main/java/net/madnation/zeus/contextual/xposed/SystemUI_hook.java
@@ -47,7 +47,7 @@ public class SystemUI_hook implements IXposedHookZygoteInit, IXposedHookInitPack
                     navbar.setPadding(navbar.getPaddingLeft(), navbar.getPaddingTop(), navbar.getPaddingRight(), 0);
                 }
                 ViewGroup VG = (ViewGroup) liparam.view;
-                boolean isImageView = VG.getChildAt(0).getClass().getName() == net.madnation.zeus.contextual.xposed.TopCropImageView.class.getName();
+                boolean isImageView = VG.getChildAt(0).getClass().getName().equals(net.madnation.zeus.contextual.xposed.TopCropImageView.class.getName());
 
                 if (!isImageView) {
                     XSharedPreferences prefs = new XSharedPreferences(PACKAGE_NAME, PACKAGE_NAME);

--- a/app/src/main/java/net/madnation/zeus/contextual/xposed/TopCropImageView.java
+++ b/app/src/main/java/net/madnation/zeus/contextual/xposed/TopCropImageView.java
@@ -42,6 +42,7 @@ public class TopCropImageView extends ImageView {
     public TopCropImageView(Context context, XModuleResources modRes, XSharedPreferences prefs) {
         super(context);
         setScaleType(ScaleType.MATRIX);
+        setClipToOutline(true);
         this.modRes = modRes;
         this.prefs = prefs;
     }


### PR DESCRIPTION
Android N-ify needs to disable clipping of the header in order to support QS animations. This also causes the ImageView to overdraw, thus blocking half of the notifications and Quick Settings. Fix this by letting the Image crop itself to it's bounds which are the same size of the header.
